### PR TITLE
Load json for using its function

### DIFF
--- a/validate-html.el
+++ b/validate-html.el
@@ -35,6 +35,7 @@
 ;;; Code:
 
 (require 'seq)
+(require 'json)
 
 (defun validate-html ()
   "Send the current buffer's file to the W3C HTML Validator.


### PR DESCRIPTION
Fix a following warning.

```
In end of data:
validate-html.el:91:31:Warning: the function ‘json-read’ is not known to be
    defined.
```